### PR TITLE
チーム情報の操作に関する機能を修正　Feature/issues #1

### DIFF
--- a/app/controllers/assigns_controller.rb
+++ b/app/controllers/assigns_controller.rb
@@ -30,6 +30,8 @@ class AssignsController < ApplicationController
       I18n.t('views.messages.cannot_delete_the_leader')
     elsif Assign.where(user_id: assigned_user.id).count == 1
       I18n.t('views.messages.cannot_delete_only_a_member')
+    elsif current_user.id != assign.team.owner.id && current_user.id != assigned_user.id
+      I18n.t('views.messages.cannot_delete_not_the_leader_or_myself')
     elsif assign.destroy
       set_next_team(assign, assigned_user)
       I18n.t('views.messages.delete_member')
@@ -37,11 +39,11 @@ class AssignsController < ApplicationController
       I18n.t('views.messages.cannot_delete_member_4_some_reason')
     end
   end
-  
+
   def email_reliable?(address)
     address.match(/\A[\w+\-.]+@[a-z\d\-.]+\.[a-z]+\z/i)
   end
-  
+
   def set_next_team(assign, assigned_user)
     another_team = Assign.find_by(user_id: assigned_user.id).team
     change_keep_team(assigned_user, another_team) if assigned_user.keep_team_id == assign.team_id

--- a/app/controllers/teams_controller.rb
+++ b/app/controllers/teams_controller.rb
@@ -15,7 +15,9 @@ class TeamsController < ApplicationController
     @team = Team.new
   end
 
-  def edit; end
+  def edit
+    redirect_to team_url, notice: I18n.t('views.messages.cannot_edit_team_info') unless @team.owner.id == current_user.id
+  end
 
   def create
     @team = Team.new(team_params)

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -212,6 +212,7 @@ ja:
       failed_to_assign: 'アサインに失敗しました！'
       cannot_delete_the_leader: 'リーダーは削除できません。'
       cannot_delete_only_a_member: 'このユーザーはこのチームにしか所属していないため、削除できません。'
+      cannot_delete_not_the_leader_or_myself: 'リーダーもしくはユーザー自身ではないため、削除できません。'
       delete_member: 'メンバーを削除しました。'
       cannot_delete_member_4_some_reason: 'なんらかの原因で、削除できませんでした。'
       failed_to_post: '投稿できませんでした...'

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -251,6 +251,7 @@ ja:
       edit_profile: 'プロフィールを編集'
       team_you_belong_to: '所属しているチーム'
       posted_articles: '投稿した記事一覧'
+      cannot_edit_team_info: 'リーダー以外はチーム情報を編集できません。'
     button:
       submit: '投稿'
       edit: '編集'


### PR DESCRIPTION
## Issue
- チーム情報の操作に関しての機能を整えること/Implement team information management function #64

## 内容
- チームに所属しているユーザーの削除は、そのチームのリーダーか、そのユーザー自身しかできないよう（条件分岐を追加し、該当しなければメッセージを表示）に修正しました。
- TeamのeditはTeamのリーダーのみが実施できるよう（該当しなければメッセージを表示）に修正しました。