### PR TITLE
アジェンダの削除機能を実装 Feature/issues #3

### DIFF
--- a/app/controllers/agendas_controller.rb
+++ b/app/controllers/agendas_controller.rb
@@ -25,6 +25,8 @@ class AgendasController < ApplicationController
     # agendaの作者もしくはそのagendaに紐づいているチームのオーナーならagendaを削除できる
     if @agenda.user.id == current_user.id || @agenda.team.owner.id == current_user.id
       @agenda.destroy
+      # agendaが削除された際にそのagendaが属するチームのメンバー全員にメールを送信する処理
+      DaleteAgendaMailer.delete_agenda_mail(@agenda).deliver
       redirect_to dashboard_path, notice: I18n.t('views.messages.delete_agenda')
     else
       redirect_to dashboard_path, notice: I18n.t('views.messages.cannnot_delete_agenda')

--- a/app/controllers/agendas_controller.rb
+++ b/app/controllers/agendas_controller.rb
@@ -1,5 +1,5 @@
 class AgendasController < ApplicationController
-  # before_action :set_agenda, only: %i[show edit update destroy]
+  before_action :set_agenda, only: %i[show edit update destroy]
 
   def index
     @agendas = Agenda.all
@@ -15,9 +15,19 @@ class AgendasController < ApplicationController
     @agenda.team = Team.friendly.find(params[:team_id])
     current_user.keep_team_id = @agenda.team.id
     if current_user.save && @agenda.save
-      redirect_to dashboard_url, notice: I18n.t('views.messages.create_agenda') 
+      redirect_to dashboard_url, notice: I18n.t('views.messages.create_agenda')
     else
       render :new
+    end
+  end
+
+  def destroy
+    # agendaの作者もしくはそのagendaに紐づいているチームのオーナーならagendaを削除できる
+    if @agenda.user.id == current_user.id || @agenda.team.owner.id == current_user.id
+      @agenda.destroy
+      redirect_to dashboard_path, notice: I18n.t('views.messages.delete_agenda')
+    else
+      redirect_to dashboard_path, notice: I18n.t('views.messages.cannnot_delete_agenda')
     end
   end
 

--- a/app/mailers/dalete_agenda_mailer.rb
+++ b/app/mailers/dalete_agenda_mailer.rb
@@ -1,0 +1,6 @@
+class DaleteAgendaMailer < ApplicationMailer
+  def delete_agenda_mail(agenda)
+    @agenda = agenda
+    mail to: @agenda.team.users.pluck(:email), subject: I18n.t('views.messages.delete_agenda')
+  end
+end

--- a/app/views/dalete_agenda_mailer/delete_agenda_mail.html.erb
+++ b/app/views/dalete_agenda_mailer/delete_agenda_mail.html.erb
@@ -1,0 +1,3 @@
+<h1><%= I18n.t('views.messages.delete_agenda') %></h1>
+
+<h4><%= I18n.t('views.messages.delete_agenda_title', :agenda => "#{@agenda.title}" ) %></h4>

--- a/app/views/shared/layout/_sidebar.html.erb
+++ b/app/views/shared/layout/_sidebar.html.erb
@@ -35,7 +35,9 @@
               <a>
                 <%= agenda.title %>
                 <i class="right fa fa-angle-left"></i>
-                <p><%= link_to 'delete', agenda_path(agenda), method: :delete, class: 'btn btn-sm btn-danger'%></p>
+                <% if agenda.user.id == current_user.id || agenda.team.owner.id == current_user.id %>
+                  <p><%= link_to 'delete', agenda_path(agenda), method: :delete, class: 'btn btn-sm btn-danger'%></p>
+                <% end %>
               </a>
             </div>
             <ul class="nav nav-treeview" style="display: block;">

--- a/app/views/shared/layout/_sidebar.html.erb
+++ b/app/views/shared/layout/_sidebar.html.erb
@@ -30,13 +30,14 @@
       <ul class="nav nav-pills nav-sidebar flex-column" data-widget="treeview" role="menu" data-accordion="false">
         <% @working_team.agendas.each do |agenda| %>
           <li class="nav-item has-treeview menu-open">
-            <a href="#" class="nav-link">
+            <div class="nav-link">
               <i class="fa fa-circle-o nav-icon"></i>
-              <p>
+              <a>
                 <%= agenda.title %>
                 <i class="right fa fa-angle-left"></i>
-              </p>
-            </a>
+                <p><%= link_to 'delete', agenda_path(agenda), method: :delete, class: 'btn btn-sm btn-danger'%></p>
+              </a>
+            </div>
             <ul class="nav nav-treeview" style="display: block;">
               <% agenda.articles.each do |article| %>
                 <li class="nav-item">

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -238,6 +238,8 @@ ja:
       team_build2: 'チームを作成する'
       select_team: 'チーム選択'
       create_agenda: 'アジェンダ作成'
+      delete_agenda: 'アジェンダを削除しました。'
+      cannnot_delete_agenda: '権限がないため、アジェンダを削除できませんでした。'
       input_agenda_title: 'タイトル入力'
       input_team_name: 'チーム名を入力してください'
       recent_posts: '最近投稿された記事'

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -239,6 +239,7 @@ ja:
       select_team: 'チーム選択'
       create_agenda: 'アジェンダ作成'
       delete_agenda: 'アジェンダを削除しました。'
+      delete_agenda_title: "アジェンダ「%{agenda}」を削除しました。"
       cannnot_delete_agenda: '権限がないため、アジェンダを削除できませんでした。'
       input_agenda_title: 'タイトル入力'
       input_team_name: 'チーム名を入力してください'

--- a/spec/mailers/dalete_agenda_mailer_spec.rb
+++ b/spec/mailers/dalete_agenda_mailer_spec.rb
@@ -1,0 +1,5 @@
+require "rails_helper"
+
+RSpec.describe DaleteAgendaMailer, type: :mailer do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/mailers/previews/dalete_agenda_mailer_preview.rb
+++ b/spec/mailers/previews/dalete_agenda_mailer_preview.rb
@@ -1,0 +1,4 @@
+# Preview all emails at http://localhost:3000/rails/mailers/dalete_agenda_mailer
+class DaleteAgendaMailerPreview < ActionMailer::Preview
+
+end


### PR DESCRIPTION
# Issue
- アジェンダの削除機能を実装すること（紐づいている記事も削除し、そのアジェンダのチームに属しているメンバー全員に通知メールを送信すること）/Implement the agenda delete function（ Delete the article associated with the agenda and send a notification email to all members in the team） #67
# 内容
- アジェンダの削除機能を実装しました。
- 削除した際にそのアジェンダに紐づくチームに属するユーザー全員にお知らせメールを送信する機能も合わせて実装しました。